### PR TITLE
Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ If you are using the [SQL tagged template literals](https://marketplace.visualst
 
 Otherwise you can configure the behavior of this plugin in the `plugins` section of in your `tsconfig`.
 
+### Enable diagnostics
+
+Diagnostics include parsing of the SQL statements and type checking if a schema file is configured. It's enabled by default. You can disable it using the `enableDiagnostics` setting:
+
+```json
+{
+	"compilerOptions": {
+		"plugins": [
+			{
+				"name": "typescript-sql-tagged-template-plugin",
+				"enableDiagnostics": false
+			}
+		]
+	}
+}
+```
+
+### Enable format
+
+If you have Perl installed locally, you can enable formatting support. It's using [pgFormatter](https://github.com/darold/pgFormatter) under the hood. Enable using the `enableFormat` setting:
+
+```json
+{
+	"compilerOptions": {
+		"plugins": [
+			{
+				"name": "typescript-sql-tagged-template-plugin",
+				"enableFormat": true
+			}
+		]
+	}
+}
+```
+
 ### Database schema
 
 In order to do type checking for parameters in SQL statements, the plugin needs to know about your database schema. You can generate a JSON file with your DB schema using the script [scripts/schema/index.js](./scripts/schema/index.js). If you have a different DB type conversion, modify the file afterwards.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ TypeScript server plugin that adds type checking for SQL queries tagged with an 
 
 - Syntax errors for SQL statements
 - Type checking for expressions in SQL statements
+- Formatting of SQL statements (using [pgFormatter](https://github.com/darold/pgFormatter), requires Perl)
 
 **Limitations**
 
@@ -15,7 +16,7 @@ TypeScript server plugin that adds type checking for SQL queries tagged with an 
 
 ## Usage
 
-This plugin can provides SQL syntax errors and type checking in TypeScript files within any editor that uses TypeScript to power their language features. This includes [VS Code](https://code.visualstudio.com) and any other editor using supporting TypeScript language server plugins.
+This plugin provides SQL syntax errors and type checking in TypeScript files within any editor that uses TypeScript to power their language features. This includes [VS Code](https://code.visualstudio.com) and any other editor using supporting TypeScript language server plugins.
 
 ### With VS Code
 
@@ -45,15 +46,13 @@ Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang
 
 Then restart the TS language server.
 
+Note for VS Code users: If you're using this way of installing the plugin for VS Code, be aware of the following gotcha. By default VS Code starts two TypeScript servers, one for semantics and one for syntax. The syntax server does not load plugins installed this way. Since formatting is done with the syntax server, it won't work unless you disable the "TypeScript > Tsserver: Use Separate Syntax Server" setting.
+
 ## Configuration
 
 If you are using the [SQL tagged template literals](https://marketplace.visualstudio.com/items?itemName=frigus02.vscode-sql-tagged-template-literals) extension for VS Code, you can configure these settings in the editor settings.
 
-Otherwise you can configure the behavior of this plugin in the `plugins` section of in your `tsconfig`.
-
-### Enable diagnostics
-
-Diagnostics include parsing of the SQL statements and type checking if a schema file is configured. It's enabled by default. You can disable it using the `enableDiagnostics` setting:
+Otherwise you can configure the behavior of this plugin in the `plugins` section of in your `tsconfig`. The following options are available:
 
 ```json
 {
@@ -61,62 +60,17 @@ Diagnostics include parsing of the SQL statements and type checking if a schema 
 		"plugins": [
 			{
 				"name": "typescript-sql-tagged-template-plugin",
-				"enableDiagnostics": false
-			}
-		]
-	}
-}
-```
-
-### Enable format
-
-If you have Perl installed locally, you can enable formatting support. It's using [pgFormatter](https://github.com/darold/pgFormatter) under the hood. Enable using the `enableFormat` setting:
-
-```json
-{
-	"compilerOptions": {
-		"plugins": [
-			{
-				"name": "typescript-sql-tagged-template-plugin",
-				"enableFormat": true
-			}
-		]
-	}
-}
-```
-
-### Database schema
-
-In order to do type checking for parameters in SQL statements, the plugin needs to know about your database schema. You can generate a JSON file with your DB schema using the script [scripts/schema/index.js](./scripts/schema/index.js). If you have a different DB type conversion, modify the file afterwards.
-
-Then configure the path to the file using the `schemaFile` setting:
-
-```json
-{
-	"compilerOptions": {
-		"plugins": [
-			{
-				"name": "typescript-sql-tagged-template-plugin",
-				"schemaFile": "./path/to/database-schema.json"
-			}
-		]
-	}
-}
-```
-
-### Default schema name
-
-For queries not specifying any schema name (e.g. `SELECT * FROM users` instead of `SELECT * FROM myschema.users`), the plugin uses this as the default schema. The value defaults to `public`, which is the Postgres default.
-
-```json
-{
-	"compilerOptions": {
-		"plugins": [
-			{
-				"name": "typescript-sql-tagged-template-plugin",
+				"enableDiagnostics": true,
+				"enableFormat": true,
+				"schemaFile": "./path/to/database-schema.json",
 				"defaultSchemaName": "public"
 			}
 		]
 	}
 }
 ```
+
+- `enableDiagnostics`: Diagnostics include parsing of the SQL statements and type checking if a schema file is configured. It's enabled by default.
+- `enableFormat`: Formatting is done using [pgFormatter](https://github.com/darold/pgFormatter) and requires Perl. If Perl is available, formatting is enabled by default.
+- `schemaFile`: In order to do type checking for parameters in SQL statements, the plugin needs to know about your database schema. You can generate a JSON file with your DB schema using the script [scripts/schema/index.js](./scripts/schema/index.js). If you have a different DB type conversion, modify the file afterwards. Then use this setting to specify the path to the file.
+- `defaultSchemaName`: For queries not specifying any schema name (e.g. `SELECT * FROM users` instead of `SELECT * FROM myschema.users`), the plugin uses this as the default schema. The value defaults to `public`, which is the Postgres default.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"build"
 	],
 	"dependencies": {
-		"pg-formatter": "^1.1.2",
+		"pg-formatter": "^1.2.0",
 		"pg-query-emscripten": "^0.1.0",
 		"typescript-template-language-service-decorator": "^2.2.0"
 	},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"build"
 	],
 	"dependencies": {
+		"pg-formatter": "^1.1.2",
 		"pg-query-emscripten": "^0.1.0",
 		"typescript-template-language-service-decorator": "^2.2.0"
 	},

--- a/src/analysis/__snapshots__/index.test.ts.snap
+++ b/src/analysis/__snapshots__/index.test.ts.snap
@@ -1,22 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`analyze any.sql 1`] = `
+exports[`analyze snapshots any.sql 1`] = `
 Object {
-  "parameters": Map {
-    1 => Object {
-      "column": "status",
-      "isArray": true,
-      "schema": undefined,
-      "table": "orders",
+  "parameters": Array [
+    Object {
+      "index": 1,
+      "location": 46,
+      "usedWith": Object {
+        "column": "status",
+        "isArray": true,
+        "schema": undefined,
+        "table": "orders",
+      },
     },
-  },
+  ],
   "warnings": Array [],
 }
 `;
 
-exports[`analyze select.sql 1`] = `
+exports[`analyze snapshots select.sql 1`] = `
 Object {
-  "parameters": Map {},
+  "parameters": Array [],
   "warnings": Array [],
 }
 `;

--- a/src/analysis/index.test.ts
+++ b/src/analysis/index.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from "fs";
 import { join as joinPath } from "path";
 import { analyze } from ".";
 
-describe(analyze, () => {
+describe("analyze snapshots", () => {
 	const testcaseDir = joinPath(__dirname, "__testcases__");
 	const files = readdirSync(testcaseDir);
 	for (const file of files) {
@@ -12,4 +12,23 @@ describe(analyze, () => {
 			expect(result).toMatchSnapshot();
 		});
 	}
+});
+
+describe(analyze, () => {
+	test("parameter location", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND status = ANY($2)";
+		const result = analyze(sql);
+		expect(result.parameters.length).toBe(2);
+
+		const p1 = result.parameters[0];
+		const p1Text = "$" + p1.index;
+		const p1TextFromLoc = sql.substr(p1.location, p1Text.length);
+		expect(p1TextFromLoc).toBe(p1Text);
+
+		const p2 = result.parameters[1];
+		const p2Text = "$" + p2.index;
+		const p2TextFromLoc = sql.substr(p2.location, p2Text.length);
+		expect(p2TextFromLoc).toBe(p2Text);
+	});
 });

--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -17,7 +17,7 @@ import { notSupported, Warning } from "./utils";
 
 export interface Analysis {
 	warnings: Warning[];
-	parameters: Map<number, Parameter>;
+	parameters: Parameter[];
 }
 
 export class ParseError extends Error {
@@ -36,7 +36,7 @@ export const analyze = (query: string): Analysis => {
 		throw new ParseError(result.error);
 	} else if (result.parse_tree) {
 		const stmt = result.parse_tree[0];
-		let parameters;
+		let parameters: Parameter[];
 		if (isPgRawStmt(stmt) && stmt.RawStmt.stmt) {
 			const innerStmt = stmt.RawStmt.stmt;
 			if (isPgUpdateStmt(innerStmt)) {
@@ -49,11 +49,11 @@ export const analyze = (query: string): Analysis => {
 				parameters = getParamMapForDelete(innerStmt, warnings);
 			} else {
 				warnings.push(notSupported("statement", innerStmt));
-				parameters = new Map<number, Parameter>();
+				parameters = [];
 			}
 		} else {
 			warnings.push(notSupported("statement", stmt));
-			parameters = new Map<number, Parameter>();
+			parameters = [];
 		}
 
 		return {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,15 +4,21 @@ import { DatabaseSchema, parseSchema } from "./schema";
 import { Logger } from "typescript-template-language-service-decorator";
 
 export interface PluginConfiguration {
+	readonly enableDiagnostics?: boolean;
+	readonly enableFormat?: boolean;
 	readonly schemaFile?: string;
 	readonly defaultSchemaName?: string;
 }
 
 const defaults = {
+	enableDiagnostics: true,
+	enableFormat: false,
 	defaultSchemaName: "public",
 };
 
 export class ParsedPluginConfiguration {
+	enableDiagnostics: boolean = defaults.enableDiagnostics;
+	enableFormat: boolean = defaults.enableFormat;
 	schema?: DatabaseSchema;
 	defaultSchemaName: string = defaults.defaultSchemaName;
 
@@ -23,6 +29,10 @@ export class ParsedPluginConfiguration {
 
 	update(config: PluginConfiguration) {
 		this.logger.log("new config: " + JSON.stringify(config));
+
+		this.enableDiagnostics =
+			config.enableDiagnostics ?? defaults.enableDiagnostics;
+		this.enableFormat = config.enableFormat ?? defaults.enableFormat;
 
 		this.schema = undefined;
 		if (config.schemaFile) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,8 @@
 import { resolve as resolvePath } from "path";
 import * as ts from "typescript/lib/tsserverlibrary";
-import { DatabaseSchema, parseSchema } from "./schema";
 import { Logger } from "typescript-template-language-service-decorator";
+import { detectPerl } from "./formatting";
+import { DatabaseSchema, parseSchema } from "./schema";
 
 export interface PluginConfiguration {
 	readonly enableDiagnostics?: boolean;
@@ -12,7 +13,7 @@ export interface PluginConfiguration {
 
 const defaults = {
 	enableDiagnostics: true,
-	enableFormat: false,
+	enableFormat: true,
 	defaultSchemaName: "public",
 };
 
@@ -32,7 +33,12 @@ export class ParsedPluginConfiguration {
 
 		this.enableDiagnostics =
 			config.enableDiagnostics ?? defaults.enableDiagnostics;
+
 		this.enableFormat = config.enableFormat ?? defaults.enableFormat;
+		if (this.enableFormat && !detectPerl()) {
+			this.logger.log("could not find Perl in PATH; disabling format");
+			this.enableFormat = false;
+		}
 
 		this.schema = undefined;
 		if (config.schemaFile) {

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -1,12 +1,18 @@
-import { formatSql, splitSqlByParameters } from "./formatting";
+import {
+	formatSql,
+	splitSqlByParameters,
+	indentForTemplateLiteral,
+} from "./formatting";
 
 describe(formatSql, () => {
 	test("new line", () => {
 		const sql =
 			"SELECT order_id, status, description FROM orders WHERE user_id = $1 AND status = ANY($2)";
-		expect(
-			formatSql({ sql, indent: { style: "tabs" }, newLine: "\n" })
-		).toEqual(
+		const formatOptions = {
+			convertTabsToSpaces: false,
+			newLineCharacter: "\n",
+		};
+		expect(formatSql({ sql, formatOptions })).toEqual(
 			"SELECT\n\torder_id,\n\tstatus,\n\tdescription\nFROM\n\torders\nWHERE\n\tuser_id = $1\n\tAND status = ANY ($2)\n"
 		);
 	});
@@ -57,5 +63,19 @@ describe(splitSqlByParameters, () => {
 			" AND status = ANY(",
 			") AND other_user != $1",
 		]);
+	});
+});
+
+describe(indentForTemplateLiteral, () => {
+	test("indent", () => {
+		const text = "SELECT\n\t1\n";
+		const formatOptions = {
+			convertTabsToSpaces: false,
+			indentSize: 4,
+			newLineCharacter: "\n",
+		};
+		expect(
+			indentForTemplateLiteral({ text, formatOptions, lineIndentSize: 8 })
+		).toBe("\n\t\t\tSELECT\n\t\t\t\t1\n\t\t");
 	});
 });

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -1,0 +1,61 @@
+import { formatSql, splitSqlByParameters } from "./formatting";
+
+describe(formatSql, () => {
+	test("new line", () => {
+		const sql =
+			"SELECT order_id, status, description FROM orders WHERE user_id = $1 AND status = ANY($2)";
+		expect(
+			formatSql({ sql, indent: { style: "tabs" }, newLine: "\n" })
+		).toEqual(
+			"SELECT\n\torder_id,\n\tstatus,\n\tdescription\nFROM\n\torders\nWHERE\n\tuser_id = $1\n\tAND status = ANY ($2)\n"
+		);
+	});
+});
+
+describe(splitSqlByParameters, () => {
+	test("no parameters", () => {
+		const sql = "SELECT 1";
+		expect(splitSqlByParameters(sql, 0)).toEqual(["SELECT 1"]);
+	});
+
+	test("ordered parameters", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND status = ANY($2)";
+		expect(splitSqlByParameters(sql, 2)).toEqual([
+			"SELECT * FROM orders WHERE user_id = ",
+			" AND status = ANY(",
+			")",
+		]);
+	});
+
+	test("only splits at parameter <= numberOfParameters", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND status = ANY($2)";
+		expect(splitSqlByParameters(sql, 1)).toEqual([
+			"SELECT * FROM orders WHERE user_id = ",
+			" AND status = ANY($2)",
+		]);
+	});
+
+	test("throws when available parameters < numberOfParameters 1", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND status = ANY($2)";
+		expect(() => splitSqlByParameters(sql, 3)).toThrow();
+	});
+
+	test("throws when available parameters < numberOfParameters 2", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND other_user != $1";
+		expect(() => splitSqlByParameters(sql, 2)).toThrow();
+	});
+
+	test("only splits on first occurrence of duplicate parameter", () => {
+		const sql =
+			"SELECT * FROM orders WHERE user_id = $1 AND status = ANY($2) AND other_user != $1";
+		expect(splitSqlByParameters(sql, 2)).toEqual([
+			"SELECT * FROM orders WHERE user_id = ",
+			" AND status = ANY(",
+			") AND other_user != $1",
+		]);
+	});
+});

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -72,10 +72,24 @@ describe(indentForTemplateLiteral, () => {
 		const formatOptions = {
 			convertTabsToSpaces: false,
 			indentSize: 4,
+			tabSize: 4,
 			newLineCharacter: "\n",
 		};
 		expect(
-			indentForTemplateLiteral({ text, formatOptions, lineIndentSize: 8 })
+			indentForTemplateLiteral({ text, formatOptions, lineIndent: 8 })
+		).toBe("\n\t\t\tSELECT\n\t\t\t\t1\n\t\t");
+	});
+
+	test("line indent doesn't divide by tab size", () => {
+		const text = "SELECT\n\t1\n";
+		const formatOptions = {
+			convertTabsToSpaces: false,
+			indentSize: 4,
+			tabSize: 4,
+			newLineCharacter: "\n",
+		};
+		expect(
+			indentForTemplateLiteral({ text, formatOptions, lineIndent: 6 })
 		).toBe("\n\t\t\tSELECT\n\t\t\t\t1\n\t\t");
 	});
 });

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -5,13 +5,10 @@ import {
 } from "./formatting";
 
 describe(formatSql, () => {
-	test("new line", () => {
+	test("it works", () => {
 		const sql =
 			"SELECT order_id, status, description FROM orders WHERE user_id = $1 AND status = ANY($2)";
-		const formatOptions = {
-			convertTabsToSpaces: false,
-			newLineCharacter: "\n",
-		};
+		const formatOptions = {};
 		expect(formatSql({ sql, formatOptions })).toEqual(
 			"SELECT\n\torder_id,\n\tstatus,\n\tdescription\nFROM\n\torders\nWHERE\n\tuser_id = $1\n\tAND status = ANY ($2)\n"
 		);
@@ -67,7 +64,7 @@ describe(splitSqlByParameters, () => {
 });
 
 describe(indentForTemplateLiteral, () => {
-	test("indent", () => {
+	test("simple case", () => {
 		const text = "SELECT\n\t1\n";
 		const formatOptions = {
 			convertTabsToSpaces: false,

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -10,6 +10,22 @@ export const detectPerl = (): boolean => {
 	}
 };
 
-export const formatText = (sql: string, spaces?: number): string => {
-	return format(sql, { spaces });
+interface IndentStyleTabs {
+	style: "tabs";
+}
+
+interface IndentStyleSpaces {
+	style: "spaces";
+	number: number;
+}
+
+export const formatText = (
+	sql: string,
+	indent: IndentStyleTabs | IndentStyleSpaces
+): string => {
+	return format(sql, {
+		noRcFile: true,
+		spaces: indent.style === "spaces" ? indent.number : undefined,
+		tabs: indent.style === "tabs",
+	});
 };

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,5 +1,6 @@
 import { execSync } from "child_process";
 import { format } from "pg-formatter";
+import { analyze } from "./analysis";
 
 export const detectPerl = (): boolean => {
 	try {
@@ -19,13 +20,64 @@ interface IndentStyleSpaces {
 	number: number;
 }
 
-export const formatText = (
+export const formatSql = ({
+	sql,
+	indent,
+	newLine,
+}: {
+	sql: string;
+	indent: IndentStyleTabs | IndentStyleSpaces;
+	newLine: string;
+}): string => {
+	try {
+		return format(sql, {
+			noRcFile: true,
+			spaces: indent.style === "spaces" ? indent.number : undefined,
+			tabs: indent.style === "tabs",
+		}).replace(/(\r\n|\r|\n)/g, newLine);
+	} catch (err) {
+		throw new Error(`pgFormatter failed: ${err.message}`);
+	}
+};
+
+export const splitSqlByParameters = (
 	sql: string,
-	indent: IndentStyleTabs | IndentStyleSpaces
-): string => {
-	return format(sql, {
-		noRcFile: true,
-		spaces: indent.style === "spaces" ? indent.number : undefined,
-		tabs: indent.style === "tabs",
-	});
+	numberOfParameters: number
+): string[] => {
+	const analysis = analyze(sql);
+	const parameters = analysis.parameters
+		.filter((parameter) => parameter.index <= numberOfParameters)
+		// Remove duplicate indexes (e.g. two times $1) and keep only the
+		// parameter that occurs first.
+		.sort((a, b) => {
+			const byIndex = a.index - b.index;
+			if (byIndex !== 0) {
+				return byIndex;
+			}
+
+			return a.location - b.location;
+		})
+		.filter(
+			(parameter, index, array) =>
+				index === 0 || array[index - 1].index !== parameter.index
+		)
+		// Sort by location
+		.sort((a, b) => a.location - b.location);
+
+	if (parameters.length !== numberOfParameters) {
+		throw new Error(
+			`SQL does not contain expected number of parameters (expected: ${numberOfParameters}, actual: ${parameters.length})`
+		);
+	}
+
+	const parts = [];
+	let end = 0;
+	for (const parameter of parameters) {
+		const pText = "$" + parameter.index;
+		parts.push(sql.substring(end, parameter.location));
+		end = parameter.location + pText.length;
+	}
+
+	parts.push(sql.substring(end));
+	return parts;
 };

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+import { format } from "pg-formatter";
+
+export const detectPerl = (): boolean => {
+	try {
+		execSync("perl -v");
+		return true;
+	} catch (err) {
+		return false;
+	}
+};
+
+export const formatText = (sql: string, spaces?: number): string => {
+	return format(sql, { spaces });
+};

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -3,6 +3,10 @@ import { format } from "pg-formatter";
 import * as ts from "typescript/lib/tsserverlibrary";
 import { analyze } from "./analysis";
 
+const DEFAULT_TAB_SIZE = 4;
+const DEFAULT_INDENT_SIZE = 4;
+const DEFAULT_NEW_LINE_CHARACTER = "\n";
+
 export const detectPerl = (): boolean => {
 	try {
 		execSync("perl -v");
@@ -23,9 +27,14 @@ export const formatSql = ({
 	try {
 		return format(sql, {
 			noRcFile: true,
-			spaces: useSpaces ? formatOptions.indentSize ?? 4 : undefined,
+			spaces: useSpaces
+				? formatOptions.indentSize ?? DEFAULT_INDENT_SIZE
+				: undefined,
 			tabs: !useSpaces,
-		}).replace(/(\r\n|\r|\n)/g, formatOptions.newLineCharacter ?? "\n");
+		}).replace(
+			/(\r\n|\r|\n)/g,
+			formatOptions.newLineCharacter ?? DEFAULT_NEW_LINE_CHARACTER
+		);
 	} catch (err) {
 		throw new Error(`pgFormatter failed: ${err.message}`);
 	}
@@ -76,19 +85,17 @@ export const splitSqlByParameters = (
 export const indentForTemplateLiteral = ({
 	text,
 	formatOptions,
-	lineIndentSize,
+	lineIndent,
 }: {
 	text: string;
 	formatOptions: ts.EditorSettings;
-	lineIndentSize: number;
+	lineIndent: number;
 }): string => {
 	const useSpaces = formatOptions.convertTabsToSpaces ?? false;
-	const indentChar = useSpaces ? " " : "\t";
-	const indentSize = useSpaces ? formatOptions.indentSize ?? 4 : 1;
-	const newLineCharacter = formatOptions.newLineCharacter ?? "\n";
-	if (!useSpaces) {
-		lineIndentSize /= formatOptions.indentSize ?? 4;
-	}
+	const indentSize = formatOptions.indentSize ?? DEFAULT_INDENT_SIZE;
+	const tabSize = formatOptions.tabSize ?? DEFAULT_TAB_SIZE;
+	const newLineCharacter =
+		formatOptions.newLineCharacter ?? DEFAULT_NEW_LINE_CHARACTER;
 
 	return (
 		newLineCharacter +
@@ -96,11 +103,41 @@ export const indentForTemplateLiteral = ({
 			.split(newLineCharacter)
 			.map((line, index, array) => {
 				const isLast = index + 1 === array.length;
-				const indent = indentChar.repeat(
-					isLast ? lineIndentSize : lineIndentSize + indentSize
-				);
-				return indent + line;
+				const indent = isLast ? lineIndent : lineIndent + indentSize;
+				const indentStr = useSpaces
+					? " ".repeat(indent)
+					: "\t".repeat(Math.ceil(indent / tabSize));
+				return indentStr + line;
 			})
 			.join(newLineCharacter)
 	);
+};
+
+export const getLineIndentationByNode = (
+	node: ts.Node,
+	scriptInfo: ts.server.ScriptInfo,
+	formatOptions: ts.EditorSettings
+): number => {
+	const { line } = scriptInfo.positionToLineOffset(
+		node.getStart(node.getSourceFile())
+	);
+	const lineSpan = scriptInfo.lineToTextSpan(line - 1);
+	const lineText = scriptInfo
+		.getSnapshot()
+		.getText(lineSpan.start, lineSpan.start + lineSpan.length);
+
+	// This logic is copied from:
+	// https://github.com/microsoft/TypeScript/blob/ee570402769c3392d82a746fdf1416e4ce96304d/src/server/session.ts#L1728-1740
+	let lineIndent = 0;
+	for (let i = 0; i < lineText.length; i++) {
+		if (lineText.charAt(i) === " ") {
+			lineIndent++;
+		} else if (lineText.charAt(i) === "\t") {
+			lineIndent += formatOptions.tabSize ?? DEFAULT_TAB_SIZE;
+		} else {
+			break;
+		}
+	}
+
+	return lineIndent;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ class SqlTaggedTemplatePlugin implements ts.server.PluginModule {
 		);
 
 		const sqlTemplateLanguageService = new SqlTemplateLanguageService(
+			info.project,
 			logger,
 			this.config,
 			typeChecker,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import VirtualServiceHost from "./virtual-service-host";
 
 const pluginMarker = Symbol("__sqlTaggedTemplatePluginMarker__");
 
-class SqlTaggedTemplatePlugin {
+class SqlTaggedTemplatePlugin implements ts.server.PluginModule {
 	private config?: ParsedPluginConfiguration;
 
 	constructor(private readonly typescript: typeof ts) {}
@@ -34,7 +34,10 @@ class SqlTaggedTemplatePlugin {
 			{ strict: true },
 			info.project.getCurrentDirectory()
 		);
-		const typeChecker = new TypeChecker(this.typescript, virtualServiceHost);
+		const typeChecker = new TypeChecker(
+			this.typescript,
+			virtualServiceHost
+		);
 		const typeResolver = new TypeResolver(this.typescript, () =>
 			info.languageService.getProgram()!.getTypeChecker()
 		);
@@ -70,5 +73,7 @@ class SqlTaggedTemplatePlugin {
 	}
 }
 
-export = (mod: { typescript: typeof ts }) =>
+const factory: ts.server.PluginModuleFactory = (mod) =>
 	new SqlTaggedTemplatePlugin(mod.typescript);
+
+export = factory;

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -192,6 +192,7 @@ export default class SqlTemplateLanguageService
 			context.node
 		);
 		const diagnostics = Array.from(analysis.parameters.entries())
+			.filter(([index]) => expressions.length >= index)
 			.map(([index, parameter]) => ({
 				expression: expressions[index - 1],
 				parameter,

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -12,6 +12,7 @@ import {
 	formatSql,
 	splitSqlByParameters,
 	indentForTemplateLiteral,
+	getLineIndentationByNode,
 } from "./formatting";
 import { DatabaseSchema, ColumnDefinition } from "./schema";
 import { TypeChecker } from "./type-checker";
@@ -261,10 +262,9 @@ export default class SqlTemplateLanguageService
 		}
 
 		const text = context.text;
-		const languageService = this.project.getLanguageService(false);
-		const lineIndentSize = languageService.getIndentationAtPosition(
-			context.fileName,
-			context.node.getStart(context.node.getSourceFile()),
+		const lineIndent = getLineIndentationByNode(
+			context.node,
+			this.project.getScriptInfo(context.fileName)!,
 			settings
 		);
 		try {
@@ -275,7 +275,7 @@ export default class SqlTemplateLanguageService
 			const formattedAndIndented = indentForTemplateLiteral({
 				text: formatted,
 				formatOptions: settings,
-				lineIndentSize,
+				lineIndent,
 			});
 			if (formattedAndIndented !== text) {
 				const literals = getTemplateLiterals(

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -240,16 +240,21 @@ export default class SqlTemplateLanguageService
 		end: number,
 		settings: ts.EditorSettings
 	): ts.TextChange[] {
-		this.logger.log(
-			"format requested. config: " + this.config.enableFormat
-		);
 		if (!this.config.enableFormat) {
 			return [];
 		}
 
 		const text = context.text.substring(start, end);
 		try {
-			const newText = formatText(text, settings.tabSize);
+			const newText = formatText(
+				text,
+				settings.convertTabsToSpaces
+					? {
+							style: "spaces",
+							number: settings.indentSize ?? 4,
+					  }
+					: { style: "tabs" }
+			);
 			if (newText !== context.text) {
 				return [
 					{

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -4,11 +4,11 @@ import {
 	TemplateLanguageService,
 } from "typescript-template-language-service-decorator";
 import * as ts from "typescript/lib/tsserverlibrary";
-import { format } from "pg-formatter";
 import { Analysis, analyze, ParseError } from "./analysis";
 import { Parameter } from "./analysis/params";
 import { pluginName } from "./config";
 import { ParsedPluginConfiguration } from "./configuration";
+import { formatText } from "./formatting";
 import { DatabaseSchema, ColumnDefinition } from "./schema";
 import { TypeChecker } from "./type-checker";
 import { TypeResolver } from "./type-resolver";
@@ -248,9 +248,7 @@ export default class SqlTemplateLanguageService
 
 		const text = context.text.substring(start, end);
 		try {
-			const newText = format(text, {
-				spaces: settings.tabSize,
-			});
+			const newText = formatText(text, settings.tabSize);
 			if (newText !== context.text) {
 				return [
 					{

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "typescript": "^3.5.3",
+    "typescript": "^4.1.2",
     "typescript-sql-tagged-template-plugin": "file:./.."
   }
 }

--- a/test-project/tsconfig.json
+++ b/test-project/tsconfig.json
@@ -6,8 +6,7 @@
 		"plugins": [
 			{
 				"name": "C:\\code\\typescript-sql-tagged-template-plugin\\build",
-				"schemaFile": "./db-schema.json",
-				"enableFormat": true
+				"schemaFile": "./db-schema.json"
 			}
 		]
 	}

--- a/test-project/tsconfig.json
+++ b/test-project/tsconfig.json
@@ -5,8 +5,9 @@
 		"lib": [],
 		"plugins": [
 			{
-				"name": "/Users/jkuehle/Projects/typescript-sql-tagged-template-plugin/build",
-				"schemaFile": "./db-schema.json"
+				"name": "C:\\code\\typescript-sql-tagged-template-plugin\\build",
+				"schemaFile": "./db-schema.json",
+				"enableFormat": true
 			}
 		]
 	}

--- a/test-project/yarn.lock
+++ b/test-project/yarn.lock
@@ -2,14 +2,27 @@
 # yarn lockfile v1
 
 
+pg-formatter@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pg-formatter/-/pg-formatter-1.1.2.tgz#f30f7bb3789b18084a0038d8f9580e70dde19cb4"
+  integrity sha512-yNCPb+8nJaHjIc7zzJbSgPkF6MTWIwTsk/ray6GUEdMzoQokxy8gsSAjeCXI0orwPoL05Yi63sy9QgTy4+CFQA==
+  dependencies:
+    shell-quote "^1.7.2"
+
 pg-query-emscripten@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/pg-query-emscripten/-/pg-query-emscripten-0.1.0.tgz#a4c6c7c6b3645ab0a4436bf650f3bcdf5b530c23"
   integrity sha512-Awwf0s6gyVZEmZeMLXnXZOIQveqVEBFhxMkR0UcMmijwX/y9FW1od71X1hNRtGFWrU/ML5sxerZyH20pvpLGuA==
 
+shell-quote@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
 "typescript-sql-tagged-template-plugin@file:./..":
-  version "0.0.1"
+  version "0.0.16"
   dependencies:
+    pg-formatter "^1.1.2"
     pg-query-emscripten "^0.1.0"
     typescript-template-language-service-decorator "^2.2.0"
 
@@ -18,7 +31,7 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==

--- a/typings/pg-formatter/index.d.ts
+++ b/typings/pg-formatter/index.d.ts
@@ -1,11 +1,13 @@
 declare module "pg-formatter" {
 	interface UserConfiguration {
 		anonymize?: boolean;
-		functionCase?: 'unchanged' | 'lowercase' | 'uppercase' | 'capitalize';
-		keywordCase?: 'unchanged' | 'lowercase' | 'uppercase' | 'capitalize';
+		functionCase?: "unchanged" | "lowercase" | "uppercase" | "capitalize";
+		keywordCase?: "unchanged" | "lowercase" | "uppercase" | "capitalize";
+		noRcFile?: boolean;
 		placeholder?: string;
 		spaces?: number;
 		stripComments?: boolean;
+		tabs?: boolean;
 	}
 
 	function format(sql: string, userConfiguration?: UserConfiguration): string;

--- a/typings/pg-formatter/index.d.ts
+++ b/typings/pg-formatter/index.d.ts
@@ -1,0 +1,12 @@
+declare module "pg-formatter" {
+	interface UserConfiguration {
+		anonymize?: boolean;
+		functionCase?: 'unchanged' | 'lowercase' | 'uppercase' | 'capitalize';
+		keywordCase?: 'unchanged' | 'lowercase' | 'uppercase' | 'capitalize';
+		placeholder?: string;
+		spaces?: number;
+		stripComments?: boolean;
+	}
+
+	function format(sql: string, userConfiguration?: UserConfiguration): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,10 +2742,10 @@ pg-connection-string@^2.4.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
-pg-formatter@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/pg-formatter/-/pg-formatter-1.1.2.tgz#f30f7bb3789b18084a0038d8f9580e70dde19cb4"
-  integrity sha512-yNCPb+8nJaHjIc7zzJbSgPkF6MTWIwTsk/ray6GUEdMzoQokxy8gsSAjeCXI0orwPoL05Yi63sy9QgTy4+CFQA==
+pg-formatter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pg-formatter/-/pg-formatter-1.2.0.tgz#8ea370fdbd3736ed4ff3e419f30f59139a311efd"
+  integrity sha512-//8AJYr7Ui4fTKK8RyGxy7SjC/UaHdLdTfMEB5kmN1Sfls5I06w8t2qAcHHF6z/uHF/zxayJ3QWx2i2i73EFog==
   dependencies:
     shell-quote "^1.7.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,13 @@ pg-connection-string@^2.4.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
+pg-formatter@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pg-formatter/-/pg-formatter-1.1.2.tgz#f30f7bb3789b18084a0038d8f9580e70dde19cb4"
+  integrity sha512-yNCPb+8nJaHjIc7zzJbSgPkF6MTWIwTsk/ray6GUEdMzoQokxy8gsSAjeCXI0orwPoL05Yi63sy9QgTy4+CFQA==
+  dependencies:
+    shell-quote "^1.7.2"
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
@@ -3137,6 +3144,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Enable formatting support using pgFormatter (requires Perl). Fixes #4 

To do before merge:

- [x] Doesn't work in VS Code at the moment. That might be because VS Code doesn't use the TypeScript language server.
- [x] Placeholder substitutions (applied before formatting) need to be reverted before the text is replaced.
- [x] Need to apply proper indentation after formatting.
- [x] pgFormatter seems to require `HOME` to be set, which isn't the case for Windows. Can we work around this?

Known issues:

- Formatting seems to be quite slow in the index.ts file in the test project. Might be because of the amount of SQL tags. Not sure if we can speed this up. But formatting can be disabled, so I think this is fine.
- In VS Code Formatting only works using the "TypeScript and JavaScript language features" formatter. If you use another formatter (e.g. Prettier), it doesn't work.